### PR TITLE
feat:#1163【联动编辑】新增场景联动时，选择单个设备，选择分组后设备列表为空，且分组搜索不能点击

### DIFF
--- a/src/views/automation/linkage-edit/index.vue
+++ b/src/views/automation/linkage-edit/index.vue
@@ -117,7 +117,13 @@ const submitData = async () => {
         const res = await sceneAutomationsAdd(configForm.value);
         if (!res.error) {
           await tabStore.removeTab(route.path);
-          router.replace({ path: '/automation/scene-linkage' });
+          if (backType.value === 'device') {
+            router.replace({ path: '/device/details', query: { d_id: propsData.value.device_id } });
+          } else if (backType.value === 'config') {
+            router.replace({ path: '/device/config-detail', query: { id: propsData.value.device_config_id } });
+          } else {
+            router.replace({ path: '/automation/scene-linkage' });
+          }
         }
       }
     }

--- a/src/views/automation/linkage-edit/modules/edit-premise.vue
+++ b/src/views/automation/linkage-edit/modules/edit-premise.vue
@@ -224,9 +224,9 @@ const getDevice = async (groupId: any, name: any) => {
   const res = await deviceListAll(queryDevice.value);
   btnloading.value = true;
   deviceOptions.value = res.data || [];
-  if (!deviceOptions.value.length) {
-    selectInstRef.value = false;
-  }
+  // if (!deviceOptions.value.length) {
+  //   selectInstRef.value = false;
+  // }
 };
 // 选择设备
 const triggerSourceChange = (ifItem: any) => {

--- a/src/views/automation/scene-linkage/modules/dataList.vue
+++ b/src/views/automation/scene-linkage/modules/dataList.vue
@@ -40,7 +40,7 @@ const sceneLinkageList = ref([] as any);
 // 新建场景
 const linkAdd = () => {
   routerPushByKey('automation_linkage-edit', {
-    query: { device_id: props.device_id, device_config_id: props.device_config_id }
+    query: { device_id: props.device_id, device_config_id: props.device_config_id, backType: props.backType }
   });
 };
 

--- a/src/views/device/config-detail/modules/alarm-info.vue
+++ b/src/views/device/config-detail/modules/alarm-info.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 }>();
 const alarmAdd = () => {
   routerPushByKey('automation_linkage-edit', {
-    query: { device_config_id: props.config_id }
+    query: { device_config_id: props.config_id, backType: 'config' }
   });
 };
 </script>

--- a/src/views/device/details/modules/give-an-alarm.vue
+++ b/src/views/device/details/modules/give-an-alarm.vue
@@ -131,7 +131,7 @@ const submitCallback = async () => {
 };
 const alarmAdd = () => {
   routerPushByKey('automation_linkage-edit', {
-    query: { device_id: props.id }
+    query: { device_id: props.id, backType: 'device' }
   });
 };
 const loading = ref(false);


### PR DESCRIPTION
feat:#1163按照分组查询设备时，如果设备列表为空，取消选择器的选择框隐藏
feat:#1265修复在设备详情和设备配置详情中，新增告警成功后页面跳转到场景联动的问题